### PR TITLE
DomPDF::send: Added void return type

### DIFF
--- a/src/DomPDF.php
+++ b/src/DomPDF.php
@@ -23,7 +23,7 @@ class DomPDF extends OriginalDompdf implements IResponse {
 	 * @param INetteResponse $httpResponse
 	 * @return void
 	 */
-	function send(IRequest $httpRequest, INetteResponse $httpResponse) {
+	function send(IRequest $httpRequest, INetteResponse $httpResponse): void {
 
 		$this->render();
 		$httpResponse->setContentType('application/pdf');


### PR DESCRIPTION
PHP Fatal error:  Declaration of Holabs\DomPDF::send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse) must be compatible with              
     Nette\Application\IResponse::send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse): void in /srv/vendor/holabs/dompdf/src/DomPDF.php on line 26                                 
     Fatal error: Declaration of Holabs\DomPDF::send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse) must be compatible with Nette\Application\IResponse::send(Nette\Http\IRequest  
     $httpRequest, Nette\Http\IResponse $httpResponse): void in /srv/vendor/holabs/dompdf/src/DomPDF.php on line 26